### PR TITLE
chore(deps-dev): atualiza TypeScript para versão 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.13.3",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.11"
       }
     },
@@ -1045,10 +1045,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "test": "vitest run tests/src.test.ts",
     "test:dist": "node --test tests/dist.test.js",
-    "test:watch": "vitest tests/util-stunks.test.ts",
+    "test:watch": "vitest tests/src.test.ts",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run typecheck && npm test && npm run build && npm run test:dist"
   },
@@ -33,7 +33,7 @@
   ],
   "devDependencies": {
     "@types/node": "^24.13.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.11"
   }
 }


### PR DESCRIPTION
## Alterações

- Atualiza TypeScript da versão 5.9 para a versão 6
- Corrige o caminho do script test:watch

## Validações

- Typecheck
- Testes do código-fonte
- Build
- Testes do dist
- Inspeção do pacote npm